### PR TITLE
API: Exibir apenas eventos marcados como publicado

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::ApiController < ActionController::API
+end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::EventsController < Api::V1::ApiController
+  def index
+    @events = Event.published.all
+
+    render status: :ok, json: { events: @events.map do |event|
+      {
+        id: event.id,
+        name: event.name,
+        description: event.description.body.to_html,
+        address: event.address
+      }
+    end
+    }
+  end
+end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -6,8 +6,12 @@ class Api::V1::EventsController < Api::V1::ApiController
       {
         id: event.id,
         name: event.name,
-        description: event.description.body.to_html,
-        address: event.address
+        description: event.description.body ? event.description.body.to_html : "",
+        address: event.address,
+        logo_url: event.logo.attached? ? url_for(event.logo) : nil,
+        banner_url: event.banner.attached? ? url_for(event.banner) : nil,
+        participants_limit: event.participants_limit,
+        event_owner: event.user.name
       }
     end
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,10 @@ Rails.application.routes.draw do
 
   resources :categories, only: [ :index, :new, :create ]
   get "dashboard" => "dashboard#index"
+
+  namespace :api do
+    namespace :v1 do
+      resources :events, only: [ :index ]
+    end
+  end
 end

--- a/spec/requests/api/event_api_spec.rb
+++ b/spec/requests/api/event_api_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'Event API' do
+  context 'Get /api/v1/events' do
+    it 'success' do
+      user = create(:user)
+
+      category = Category.create!(name: 'Palestra')
+
+      event = create(
+        :event, name: 'Formação de Churrasqueiros', user: user, status: 'published',
+        address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional')
+
+      draft_event = create(
+          :event, name: 'Formação de Padeiros', user: user, status: 'draft',
+          address: 'Rua dos ipês, 343', description: 'Aprenda a fazer Pão como um profissional', categories: [ category ])
+
+      get '/api/v1/events'
+
+      expect(response).to have_http_status :success
+      expect(response.content_type).to include('application/json')
+      expect(response.parsed_body['events'][0]['name']).to include(event.name)
+      expect(response.parsed_body['events'][0]['address']).to include(event.address)
+      expect(response.parsed_body['events'][0]['description']).to include(event.description.body.to_html)
+      expect(response.parsed_body['events'][0]['id']).to eq event.id
+      expect(response.parsed_body['events']).not_to include(draft_event.name)
+      expect(response.parsed_body['events']).not_to include(draft_event.address)
+      expect(response.parsed_body['events']).not_to include(draft_event.description)
+      expect(response.parsed_body['events']).not_to include(draft_event.id)
+    end
+  end
+end

--- a/spec/requests/api/event_api_spec.rb
+++ b/spec/requests/api/event_api_spec.rb
@@ -7,9 +7,13 @@ describe 'Event API' do
 
       category = Category.create!(name: 'Palestra')
 
-      event = create(
+      event = build(
         :event, name: 'Formação de Churrasqueiros', user: user, status: 'published',
-        address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional')
+        address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional', participants_limit: 30)
+
+      event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
+      event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
+      event.save
 
       draft_event = create(
           :event, name: 'Formação de Padeiros', user: user, status: 'draft',
@@ -23,6 +27,10 @@ describe 'Event API' do
       expect(response.parsed_body['events'][0]['address']).to include(event.address)
       expect(response.parsed_body['events'][0]['description']).to include(event.description.body.to_html)
       expect(response.parsed_body['events'][0]['id']).to eq event.id
+      expect(response.parsed_body['events'][0]['logo_url']).to eq url_for(event.logo)
+      expect(response.parsed_body['events'][0]['banner_url']).to eq url_for(event.banner)
+      expect(response.parsed_body['events'][0]['participants_limit']).to eq event.participants_limit
+      expect(response.parsed_body['events'][0]['event_owner']).to eq event.user.name
       expect(response.parsed_body['events']).not_to include(draft_event.name)
       expect(response.parsed_body['events']).not_to include(draft_event.address)
       expect(response.parsed_body['events']).not_to include(draft_event.description)


### PR DESCRIPTION
Disponibiliza via GET apenas eventos marcados como publicado no endpoint /api/v1/events
![image](https://github.com/user-attachments/assets/a89f517b-36c8-473e-ab92-625d4ff91ca2)

Resolve #33  