### PR TITLE
Feat/add schedule

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -23,6 +23,10 @@
     @apply flex flex-col self-start w-2/3 gap-4 mt-10;
   }
 
+  .form_error {
+    @apply text-alert;
+  }
+
   .input {
     @apply border-2 border-primary transition-all duration-300 focus:outline-none focus:ring focus:ring-success focus:ring-offset-2 focus:ring-offset-backgroundWhite focus:border-success rounded p-2;
   }

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,7 +1,7 @@
 class SchedulesController < ApplicationController
   layout "dashboard"
   before_action :authenticate_user!
-  before_action :authorize_schedule_access, only: [ :edit, :update ]
+  before_action :authorize_schedule_access, only: [ :edit, :update, :show ]
   before_action :find_event, only: [ :new, :create, :edit, :update ]
 
   def new
@@ -35,6 +35,11 @@ class SchedulesController < ApplicationController
       flash.now[:alert] = "Não foi possível editar as datas."
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def show
+    @schedule = Schedule.find_by(id: params[:id])
+    redirect_to root_path, alert: "Acesso não autorizado." if @schedule.nil?
   end
 
   private

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -5,6 +5,10 @@ class SchedulesController < ApplicationController
   before_action :find_event, only: [ :new, :create, :edit, :update ]
 
   def new
+    if @event.schedule.present?
+      return redirect_to event_path(@event), alert: "Este evento já possui uma agenda cadastrada."
+    end
+
     @schedule = @event.build_schedule
   end
 
@@ -14,6 +18,7 @@ class SchedulesController < ApplicationController
     if @schedule.save
       redirect_to @event, notice: "Datas cadastradas com sucesso."
     else
+      flash.now[:alert] = "Não foi possível criar a agenda."
       render :new, status: :unprocessable_entity
     end
   end
@@ -27,6 +32,7 @@ class SchedulesController < ApplicationController
     if @schedule.update(schedule_params)
       redirect_to @event, notice: "Datas editadas com sucesso."
     else
+      flash.now[:alert] = "Não foi possível editar as datas."
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,9 +2,11 @@
   <%= image_tag url_for(@event.logo) %>
 <% end %>
 
-<%= link_to 'Definir data', new_event_schedule_path(@event) %>
-
-<%= link_to 'Editar horário', edit_event_schedule_path(@event) %>
+<% if @event.schedule.nil? %>
+  <%= link_to 'Agenda', new_event_schedule_path(@event) %>
+<% else %>
+  <%= link_to 'Agenda', event_schedule_path(@event, @event.schedule) %>
+<% end %>
 
 <div class="flex gap-4">
   <p class="font-bold"><%= @event.name %></p>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -6,7 +6,7 @@
 
   <% if @schedule.errors[:start_date].any? %>
     <% @schedule.errors.full_messages_for(:start_date).each do |e| %>
-      <span><%= e %></span>
+      <span class="form_error"><%= e %></span>
     <% end %>
   <% end %>
 
@@ -17,7 +17,7 @@
 
   <% if @schedule.errors[:end_date].any? %>
     <% @schedule.errors.full_messages_for(:end_date).each do |e| %>
-      <span><%= e %></span>
+      <span class="form_error"><%= e %></span>
     <% end %>
   <% end %>
 

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,0 +1,7 @@
+<%= @schedule.event.name %>
+
+<%= link_to 'Novo item', new_event_schedule_item_path(@schedule.event, @schedule) %>
+<div>
+  Data de início: <%= l(@schedule.start_date, format: '%d/%m/%Y %H:%M')%>
+  Data de fim: <%= l(@schedule.end_date, format: '%d/%m/%Y %H:%M')%>
+</div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,6 +1,7 @@
 <%= @schedule.event.name %>
 
-<%= link_to 'Novo item', new_event_schedule_item_path(@schedule.event, @schedule) %>
+<%= link_to 'Editar data', edit_event_schedule_path(@schedule.event, @schedule) %>
+
 <div>
   Data de início: <%= l(@schedule.start_date, format: '%d/%m/%Y %H:%M')%>
   Data de fim: <%= l(@schedule.end_date, format: '%d/%m/%Y %H:%M')%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :events, only: [ :index, :new, :create, :show ] do
     patch :publish, on: :member
 
-    resources :schedules, only: [ :new, :create, :edit, :update ]
+    resources :schedules, only: [ :new, :create, :edit, :update, :show ]
   end
 
   resources :categories, only: [ :index, :new, :create ]

--- a/spec/system/schedules/user_can_define_event_schedule_spec.rb
+++ b/spec/system/schedules/user_can_define_event_schedule_spec.rb
@@ -16,7 +16,7 @@ describe 'Usuário define horários de um evento' do
     visit root_path
     click_on 'Eventos'
     click_on "#{event.name}"
-    click_on 'Definir data'
+    click_on 'Agenda'
     within('#schedule-form') do
       fill_in 'Data de início', with: (Time.now + 1.day).change(hour: 8, min: 0, sec: 0)
       fill_in 'Data de fim', with: (Time.now + 2.day).change(hour: 8, min: 0, sec: 0)

--- a/spec/system/schedules/user_can_define_event_schedule_spec.rb
+++ b/spec/system/schedules/user_can_define_event_schedule_spec.rb
@@ -55,4 +55,17 @@ describe 'Usuário define horários de um evento' do
 
     expect(page).to have_content 'Data de início deve vir antes da data de fim'
   end
+
+  it 'e falha quando já possui uma agenda cadastrada' do
+    user = FactoryBot.create(:user)
+    event = FactoryBot.create(:event, user: user)
+    FactoryBot.create(:schedule, event: event)
+
+    login_as user
+
+    visit new_event_schedule_path(event)
+
+    expect(current_path).to eq event_path(event)
+    expect(page).to have_content 'Este evento já possui uma agenda cadastrada.'
+  end
 end

--- a/spec/system/schedules/user_can_edit_event_schedule_spec.rb
+++ b/spec/system/schedules/user_can_edit_event_schedule_spec.rb
@@ -28,7 +28,8 @@ describe 'Usuário edita horários do evento' do
     visit root_path
     click_on 'Eventos'
     click_on "#{event.name}"
-    click_on 'Editar horário'
+    click_on 'Agenda'
+    click_on 'Editar data'
     fill_in 'Data de início', with: (Time.now + 3.day).change(hour: 8, min: 0, sec: 0)
     fill_in 'Data de fim', with: (Time.now + 4.day).change(hour: 8, min: 0, sec: 0)
     click_on 'Salvar'

--- a/spec/system/schedules/user_can_view_event_schedule_details_spec.rb
+++ b/spec/system/schedules/user_can_view_event_schedule_details_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'Usuário vê detalhes da agenda do evento' do
+  it 'e falha pois não está autenticado' do
+    visit event_schedule_path(1, 1)
+
+    expect(current_path).to eq new_user_session_path
+  end
+
+  it 'com sucesso' do
+    user = create(:user)
+    event = create(:event, user: user)
+    schedule = create(:schedule, event: event)
+
+    login_as user
+
+    visit root_path
+    click_on 'Eventos'
+    click_on event.name
+    click_on 'Agenda'
+
+    expect(page).to have_content "Data de início: #{schedule.start_date.strftime('%d/%m/%Y %H:%M')}"
+    expect(page).to have_content "Data de fim: #{schedule.end_date.strftime('%d/%m/%Y %H:%M')}"
+    expect(current_path).to eq event_schedule_path(event, schedule)
+  end
+
+  it 'e é redirecionado para criar uma nova agenda caso nenhuma esteja cadastrada' do
+    user = create(:user)
+    event = create(:event, user: user)
+
+    login_as user
+
+    visit root_path
+    click_on 'Eventos'
+    click_on event.name
+    click_on 'Agenda'
+
+    expect(current_path).to eq new_event_schedule_path(event)
+  end
+
+  it 'e é redirecionado caso tente acessar a agenda de um evento de outro usuário' do
+    user = create(:user)
+    event = create(:event, user: user)
+    schedule = create(:schedule, event: event)
+    second_user = create(:user, email: 'joao@email.com', registration_number: CPF.generate)
+
+    login_as second_user
+
+    visit event_schedule_path(event, schedule)
+
+    expect(current_path).to eq dashboard_path
+  end
+end


### PR DESCRIPTION
resolve #42 
1. Adicionado a página show para mostrar detalhes de uma agenda: 
![image](https://github.com/user-attachments/assets/53167c87-fb59-480e-8e9e-f2bb3a37c2da)

Detalhes Técnicos

Mudança do botão de editar uma agenda da página de eventos para a página de detalhes de uma agenda.
Adicionados testes de sistema para verificação de qualidade.
Adicionado redirecionamento para a dashboard ao tentar vizualizar uma agenda de outro usuário ou que não existe.