### PR TITLE
Disponibiliza endpoint para detalhes de eventos

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::EventsController < Api::V1::ApiController
 
     render status: :ok, json: { events: @events.map do |event|
       {
-        id: event.id,
+        uuid: event.uuid,
         name: event.name,
         description: event.description.body ? event.description.body.to_html : "",
         address: event.address,
@@ -15,6 +15,26 @@ class Api::V1::EventsController < Api::V1::ApiController
         schedule: event.schedule.as_json(except: [ :created_at, :updated_at, :event_id, :id ])
       }
     end
+    }
+  end
+
+  def show
+    event = Event.published.find_by(uuid: params[:uuid])
+
+    unless event
+      return render status: :not_found, json: { error: "Event not found" }
+    end
+
+    render status: :ok, json: {
+      uuid: event.uuid,
+      name: event.name,
+      description: event.description.body ? event.description.body.to_html : "",
+      address: event.address,
+      logo_url: event.logo.attached? ? url_for(event.logo) : nil,
+      banner_url: event.banner.attached? ? url_for(event.banner) : nil,
+      participants_limit: event.participants_limit,
+      event_owner: event.user.name,
+      schedule: event.schedule.as_json(except: [ :created_at, :updated_at, :event_id, :id ])
     }
   end
 end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -11,7 +11,8 @@ class Api::V1::EventsController < Api::V1::ApiController
         logo_url: event.logo.attached? ? url_for(event.logo) : nil,
         banner_url: event.banner.attached? ? url_for(event.banner) : nil,
         participants_limit: event.participants_limit,
-        event_owner: event.user.name
+        event_owner: event.user.name,
+        schedule: event.schedule.as_json(except: [ :created_at, :updated_at, :event_id, :id ])
       }
     end
     }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,7 +45,7 @@ class Event < ApplicationRecord
   def generate_uuid
     loop do
       self.uuid = SecureRandom.uuid
-      break unless self.class.exists?(uuid: uuid)
+      break unless Event.where(uuid: uuid).exists?
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,6 +14,7 @@ class Event < ApplicationRecord
   enum :event_type, [ :inperson, :online, :hybrid ]
 
   validates :name, :participants_limit, :url, :status, presence: true
+  validates :uuid, uniqueness: true
   validates :address, presence: true, if: -> { inperson? || hybrid? }
   validates :logo, content_type: { in: [ "image/png", "image/jpeg", "image/jpg" ], message: "deve ser uma imagem do tipo PNG, JPG ou JPEG" }
   validates :banner, content_type: { in: [ "image/png", "image/jpeg", "image/jpg" ], message: "deve ser uma imagem do tipo PNG, JPG ou JPEG" }
@@ -21,6 +22,7 @@ class Event < ApplicationRecord
   validate :should_have_at_least_one_category
 
   after_initialize :set_status, if: :new_record?
+  before_validation :generate_uuid
 
   private
 
@@ -37,6 +39,13 @@ class Event < ApplicationRecord
   end
 
   def should_have_at_least_one_category
-      errors.add(:categories, "deve ter ao menos uma categoria") if categories.empty?
+    errors.add(:categories, "deve ter ao menos uma categoria") if categories.empty?
+  end
+
+  def generate_uuid
+    loop do
+      self.uuid = SecureRandom.uuid
+      break unless self.class.exists?(uuid: uuid)
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :events, only: [ :index ]
+      resources :events, param: :uuid, only: [ :index, :show ]
     end
   end
 end

--- a/db/migrate/20250127212754_add_uuid_to_events.rb
+++ b/db/migrate/20250127212754_add_uuid_to_events.rb
@@ -1,0 +1,6 @@
+class AddUuidToEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :events, :uuid, :string, null: false
+    add_index :events, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_24_205708) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_27_212754) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -84,8 +84,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_24_205708) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
+    t.string "uuid", null: false
     t.index ["discarded_at"], name: "index_events_on_discarded_at"
     t.index ["user_id"], name: "index_events_on_user_id"
+    t.index ["uuid"], name: "index_events_on_uuid"
   end
 
   create_table "keywords", force: :cascade do |t|

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -84,4 +84,19 @@ RSpec.describe Event, type: :model do
     expect(event.errors[:participants_limit]).to include 'do evento não pode ser maior que 30 para usuários não verificados'
     expect(event).not_to be_valid
   end
+
+  it 'deve criar um uuid antes de salvar o evento' do
+    event = build(:event)
+    event.valid?
+
+    expect(event.uuid).not_to be_nil
+  end
+
+  it 'deve ser um código único por evento' do
+    event1 = create(:event)
+    category = create(:category, name: 'Tecnologia')
+    event2 = build(:event, uuid: event1.uuid, categories: [ category ])
+    result = event2.valid?
+    expect(result).to be false
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -92,11 +92,13 @@ RSpec.describe Event, type: :model do
     expect(event.uuid).not_to be_nil
   end
 
-  it 'deve ser um código único por evento' do
-    event1 = create(:event)
-    category = create(:category, name: 'Tecnologia')
-    event2 = build(:event, uuid: event1.uuid, categories: [ category ])
-    result = event2.valid?
-    expect(result).to be false
+  it 'Não deve criar um uuid igual ao existente' do
+    existing_uuid = SecureRandom.uuid
+    create(:event, uuid: existing_uuid)
+    category = create(:category, name: 'Pirâmide')
+    event = build(:event, categories: [ category ], uuid: existing_uuid)
+    event.valid?
+
+    expect(event.uuid).not_to eq(existing_uuid)
   end
 end

--- a/spec/requests/api/event_api_request_spec.rb
+++ b/spec/requests/api/event_api_request_spec.rb
@@ -28,7 +28,7 @@ describe 'Event API' do
       expect(response.parsed_body['events'][0]['name']).to include(event.name)
       expect(response.parsed_body['events'][0]['address']).to include(event.address)
       expect(response.parsed_body['events'][0]['description']).to include(event.description.body.to_html)
-      expect(response.parsed_body['events'][0]['id']).to eq event.id
+      expect(response.parsed_body['events'][0]['uuid']).to eq event.uuid
       expect(response.parsed_body['events'][0]['logo_url']).to eq url_for(event.logo)
       expect(response.parsed_body['events'][0]['banner_url']).to eq url_for(event.banner)
       expect(response.parsed_body['events'][0]['participants_limit']).to eq event.participants_limit
@@ -39,6 +39,44 @@ describe 'Event API' do
       expect(response.parsed_body['events']).not_to include(draft_event.address)
       expect(response.parsed_body['events']).not_to include(draft_event.description)
       expect(response.parsed_body['events']).not_to include(draft_event.id)
+    end
+  end
+
+  context 'Get /api/v1/events/:id' do
+    it 'success' do
+      user = create(:user)
+      category = Category.create!(name: 'Palestra')
+      event = build(
+        :event, name: 'Formação de Desenvolvedores', user: user, status: 'published',
+        address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional', participants_limit: 30)
+
+      create(:schedule, event: event)
+      event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
+      event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
+
+      event.save
+
+      get "/api/v1/events/#{event.uuid}"
+
+      expect(response).to have_http_status :success
+      expect(response.content_type).to include('application/json')
+      expect(response.parsed_body['name']).to include(event.name)
+      expect(response.parsed_body['address']).to include(event.address)
+      expect(response.parsed_body['description']).to include(event.description.body.to_html)
+      expect(response.parsed_body['uuid']).to eq event.uuid
+      expect(response.parsed_body['logo_url']).to eq url_for(event.logo)
+      expect(response.parsed_body['banner_url']).to eq url_for(event.banner)
+      expect(response.parsed_body['participants_limit']).to eq event.participants_limit
+      expect(response.parsed_body['event_owner']).to eq event.user.name
+      expect(response.parsed_body['schedule']['start_date']).to eq event.schedule.start_date.iso8601(3)
+      expect(response.parsed_body['schedule']['end_date']).to eq event.schedule.end_date.iso8601(3)
+    end
+
+    it 'success' do
+      get "/api/v1/events/WRONG_UUID"
+
+      expect(response).to have_http_status :not_found
+      expect(response.content_type).to include('application/json')
     end
   end
 end

--- a/spec/requests/api/event_api_request_spec.rb
+++ b/spec/requests/api/event_api_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Event API' do
-  context 'Get /api/v1/events' do
+  context 'User sees events list' do
     it 'success' do
       user = create(:user)
 
@@ -42,10 +42,9 @@ describe 'Event API' do
     end
   end
 
-  context 'Get /api/v1/events/:id' do
+  context 'User sees Event details' do
     it 'success' do
       user = create(:user)
-      category = Category.create!(name: 'Palestra')
       event = build(
         :event, name: 'Formação de Desenvolvedores', user: user, status: 'published',
         address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional', participants_limit: 30)
@@ -72,7 +71,7 @@ describe 'Event API' do
       expect(response.parsed_body['schedule']['end_date']).to eq event.schedule.end_date.iso8601(3)
     end
 
-    it 'success' do
+    it "and event doesn't exist" do
       get "/api/v1/events/WRONG_UUID"
 
       expect(response).to have_http_status :not_found

--- a/spec/requests/api/event_api_request_spec.rb
+++ b/spec/requests/api/event_api_request_spec.rb
@@ -11,8 +11,10 @@ describe 'Event API' do
         :event, name: 'Formação de Churrasqueiros', user: user, status: 'published',
         address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional', participants_limit: 30)
 
+      create(:schedule, event: event)
       event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
       event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
+
       event.save
 
       draft_event = create(
@@ -31,6 +33,8 @@ describe 'Event API' do
       expect(response.parsed_body['events'][0]['banner_url']).to eq url_for(event.banner)
       expect(response.parsed_body['events'][0]['participants_limit']).to eq event.participants_limit
       expect(response.parsed_body['events'][0]['event_owner']).to eq event.user.name
+      expect(response.parsed_body['events'][0]['schedule']['start_date']).to eq event.schedule.start_date.iso8601(3)
+      expect(response.parsed_body['events'][0]['schedule']['end_date']).to eq event.schedule.end_date.iso8601(3)
       expect(response.parsed_body['events']).not_to include(draft_event.name)
       expect(response.parsed_body['events']).not_to include(draft_event.address)
       expect(response.parsed_body['events']).not_to include(draft_event.description)


### PR DESCRIPTION
resolve #58 

1. Adiciona um endpoint para detalhes de um evento através de um uuid.
![Screenshot 2025-01-28 163518](https://github.com/user-attachments/assets/0a246dc4-f223-4287-8e88-8b49c898aa01)


2. Feitas melhorias na entrega do endpoint da lista de eventos, que agora vem com data de inicio e fim.
![Screenshot 2025-01-28 163503](https://github.com/user-attachments/assets/e2bf360c-28a7-4816-89d1-91f1a9d2f881)

Detalhes Técnicos:
Adicionado nova validação que gera um uuid aleatório e único para cada evento ao ser criado.