### PR TITLE
Adicionados endpoints para lista de lotes de ingressos e detalhes de um lote

### DIFF
--- a/app/controllers/api/v1/ticket_batches_controller.rb
+++ b/app/controllers/api/v1/ticket_batches_controller.rb
@@ -1,0 +1,32 @@
+class Api::V1::TicketBatchesController < Api::V1::ApiController
+  def index
+    @event = Event.find_by(uuid: params[:event_uuid])
+    render status: :ok, json: { ticket_batches: @event.ticket_batches.map do |ticket_batch|
+      {
+        name: ticket_batch.name,
+        tickets_limit: ticket_batch.tickets_limit,
+        start_date: ticket_batch.start_date,
+        end_date: ticket_batch.end_date,
+        ticket_price: ticket_batch.ticket_price,
+        discount_option: ticket_batch.discount_option
+      }
+    end
+    }
+  end
+
+  def show
+    @event = Event.find_by(uuid: params[:event_uuid])
+    @ticket_batch = @event.ticket_batches.find_by(id: params[:id])
+
+    return render status: :not_found, json: { error: "Ticket batch not found" } if @ticket_batch.nil?
+
+    render status: :ok, json: { ticket_batch: {
+      name: @ticket_batch.name,
+      tickets_limit: @ticket_batch.tickets_limit,
+      start_date: @ticket_batch.start_date,
+      end_date: @ticket_batch.end_date,
+      ticket_price: @ticket_batch.ticket_price,
+      discount_option: @ticket_batch.discount_option
+    } }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :events, param: :uuid, only: [ :index, :show ]
+      resources :events, param: :uuid, only: [ :index, :show ] do
+        resources :ticket_batches, only: [ :index, :show ]
+      end
       resources :speakers, only: [ :create ]
     end
   end

--- a/spec/requests/api/v1/ticket_batch_api_request_spec.rb
+++ b/spec/requests/api/v1/ticket_batch_api_request_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe 'Ticket Batch API' do
+  context 'Usuário ve a lista de ticket batches de um evento' do
+    it 'com sucesso' do
+      user = create(:user)
+      event = create(:event, user: user)
+      create(:ticket_batch, name: 'Primeiro Lote', tickets_limit: 15, event: event)
+      create(:ticket_batch, name: 'Segundo Lote', tickets_limit: 20, event: event)
+
+      get "/api/v1/events/#{event.uuid}/ticket_batches"
+
+      expect(response).to have_http_status :ok
+      expect(response.content_type).to include('application/json')
+
+      ticket_batches = JSON.parse(response.body, symbolize_names: true)
+
+      expect(ticket_batches[:ticket_batches].length).to eq(2)
+      expect(ticket_batches[:ticket_batches][0][:name]).to eq('Primeiro Lote')
+      expect(ticket_batches[:ticket_batches][0][:tickets_limit]).to eq(15)
+      expect(ticket_batches[:ticket_batches][1][:name]).to eq('Segundo Lote')
+      expect(ticket_batches[:ticket_batches][1][:tickets_limit]).to eq(20)
+    end
+  end
+
+  context 'Usuário ve detalhes de ticket batch de um evento' do
+    it 'com sucesso' do
+      user = create(:user)
+      event = create(:event, user: user)
+      ticket_batch = create(:ticket_batch, name: 'Primeiro Lote', tickets_limit: 15,
+        start_date: 2.days.from_now, end_date: 3.days.from_now, ticket_price: 1000,
+        discount_option: :student, event: event
+      )
+
+      get "/api/v1/events/#{event.uuid}/ticket_batches/#{ticket_batch.id}"
+
+      expect(response).to have_http_status :ok
+      expect(response.content_type).to include('application/json')
+
+      ticket_batch = JSON.parse(response.body, symbolize_names: true)
+
+      expect(ticket_batch[:ticket_batch][:name]).to eq('Primeiro Lote')
+      expect(ticket_batch[:ticket_batch][:tickets_limit]).to eq(15)
+      expect(ticket_batch[:ticket_batch][:start_date]).to eq(2.days.from_now.strftime('%Y-%m-%d'))
+      expect(ticket_batch[:ticket_batch][:end_date]).to eq(3.days.from_now.strftime('%Y-%m-%d'))
+      expect(ticket_batch[:ticket_batch][:ticket_price]).to eq("500.0")
+      expect(ticket_batch[:ticket_batch][:discount_option]).to eq("student")
+    end
+
+    it 'e falha caso o ticket batch nao seja encontrado' do
+      user = create(:user)
+      event = create(:event, user: user)
+      create(:ticket_batch, name: 'Primeiro Lote', tickets_limit: 15, event: event)
+
+      get "/api/v1/events/#{event.uuid}/ticket_batches/WRONG_ID"
+
+      expect(response).to have_http_status :not_found
+      expect(response.content_type).to include('application/json')
+      expect(response.body).to include("Ticket batch not found")
+    end
+  end
+end


### PR DESCRIPTION
resolve #59 

1. Adicionados o endpoint para visualizar a lista de lotes de ingressos (ticket_batches) de um evento. "/api/v1/events/:event_uuid/ticket_batches"
![Screenshot 2025-01-29 172915](https://github.com/user-attachments/assets/1b444619-bdc5-450f-9024-d9958209d08e)

2. Adicionado o endpoint para visualizar detalhes de um lote de ingressos.
3. "/api/v1/events/:event_uuid/ticket_batches/:id"
![Screenshot 2025-01-29 173003](https://github.com/user-attachments/assets/c0e84343-70da-4317-a00e-11710c34008c)


