### PR TITLE
Melhora os detalhes dos retornos da rota de eventos da API de palestrantes

### DIFF
--- a/app/controllers/api/v1/speakers_controller.rb
+++ b/app/controllers/api/v1/speakers_controller.rb
@@ -17,10 +17,10 @@ class Api::V1::SpeakersController < Api::V1::ApiController
     speaker = Speaker.find_by(token: params[:token])
 
     if speaker
-      events = speaker.events.distinct
+      events = speaker.events.distinct.as_json(except: [ :id, :user_id, :discarded_at ])
       render json: events, status: :ok
     else
-      render json: { error: "Token não pertence a nenhuma palestrante." }, status: :not_found
+      render json: { error: "Token não pertence a nenhum palestrante." }, status: :not_found
     end
   end
 end

--- a/spec/requests/api/v1/speaker_api_request_spec.rb
+++ b/spec/requests/api/v1/speaker_api_request_spec.rb
@@ -89,7 +89,7 @@ describe 'Speaker API' do
       get "/api/v1/speakers/INVALID_TOKEN/events"
 
       json_response = JSON.parse(response.body)
-      expect(json_response["error"]). to eq 'Token não pertence a nenhuma palestrante.'
+      expect(json_response["error"]). to eq 'Token não pertence a nenhum palestrante.'
       expect(response.status).to eq 404
       expect(response.content_type).to include('application/json')
     end


### PR DESCRIPTION
- Remove campos não necessários dos eventos na resposta da requisição (id, user_id e discarded_at)
![image](https://github.com/user-attachments/assets/c3be7701-11d5-4ea8-81b4-cb1c7425a4f3)

- Conserta o texto retornado caso o token não pertença a nenhum palestrante
![image](https://github.com/user-attachments/assets/cc977f78-268c-47dc-8a8b-b3b68b550989)

Resolve #77 