### PR TITLE
Adicionado uma simples visualização de horários as atividades da agenda.

### DIFF
--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,13 +1,22 @@
-<h1><%= @schedule.event.name %> - Agenda do dia <%= l(@schedule.date.to_date, format: :short)%></h1>
+<div class="container mx-auto px-4 py-6">
+  <h1 class="text-2xl font-bold mb-6">
+    <%= @schedule.event.name %> - Agenda do dia <%= l(@schedule.date.to_date, format: :short)%>
+  </h1>
 
-<div class="flex gap-4">
-  <%= link_to 'Adicionar atividade', new_event_schedule_item_path(@schedule.event, @schedule),
-    class: 'button-primary'
-  %>
-</div>
+  <div class="mb-8">
+    <%= link_to 'Adicionar atividade', new_event_schedule_item_path(@schedule.event, @schedule),
+      class: 'button-primary'
+    %>
+  </div>
 
-<div class="mt-4" data-controller="schedule">
-  <% @schedule_items.each do |item| %>
-    <p> <%= item.name %>
-  <% end %>
+  <div class="mt-4 space-y-3" data-controller="schedule">
+    <% @schedule_items.each do |item| %>
+      <div class="flex items-center p-3 bg-gray-50 rounded-lg">
+        <span class="font-medium"><%= item.name %></span>
+        <span class="ml-auto text-gray-600">
+          <%= item.start_time.strftime("%H:%M") %> - <%= item.end_time.strftime("%H:%M") %>
+        </span>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/spec/system/schedule_items/user_can_see_schedule_items_list_spec.rb
+++ b/spec/system/schedule_items/user_can_see_schedule_items_list_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'Usuário vê lista de eventos' do
+  it 'e vê eventos' do
+    user = create(:user)
+    event = create(:event, user: user, start_date: 1.days.from_now, end_date: 5.days.from_now)
+    create(:schedule_item, name: 'Palestra', schedule: event.schedules.first,
+      start_time: '10:00', end_time: '11:00'
+    )
+    create(:schedule_item, name: 'Workshop', schedule: event.schedules.first,
+      start_time: '11:00', end_time: '12:00'
+    )
+    create(:schedule_item, name: 'Coffee Break', schedule: event.schedules.first,
+      schedule_type: :interval, start_time: '12:00', end_time: '13:00'
+    )
+
+    login_as user
+
+    visit root_path
+    click_on 'Eventos'
+    click_on 'Gerenciar'
+    click_on 1.day.from_now.strftime('%d/%m')
+
+    expect(page).to have_content('Palestra')
+    expect(page).to have_content('10:00 - 11:00')
+    expect(page).to have_content('Workshop')
+    expect(page).to have_content('11:00 - 12:00')
+    expect(page).to have_content('Coffee Break')
+    expect(page).to have_content('12:00 - 13:00')
+  end
+end

--- a/spec/system/schedule_items/user_can_see_schedule_items_list_spec.rb
+++ b/spec/system/schedule_items/user_can_see_schedule_items_list_spec.rb
@@ -16,9 +16,7 @@ describe 'Usuário vê lista de eventos' do
 
     login_as user
 
-    visit root_path
-    click_on 'Eventos'
-    click_on 'Gerenciar'
+    visit event_path(event)
     click_on 1.day.from_now.strftime('%d/%m')
 
     expect(page).to have_content('Palestra')


### PR DESCRIPTION
resolve #87 
Foi Adicionado a visualização de horários ao lado do nome da atividade para consulta das atividades cadastradas.
![image](https://github.com/user-attachments/assets/9811e6d5-62f2-414d-b0d2-900d66910134)
