### PR TITLE
Resolve bug de preços em meia-entrada e ajusta código desnecessário

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -28,12 +28,7 @@ class CategoriesController < ApplicationController
 
   def update
     @category = Category.find(params[:id])
-    if @category.update(category_params)
-      redirect_to categories_path, notice: t(".success")
-    else
-      flash.now[:alert] = t(".failure")
-      render :show, status: :unprocessable_entity
-    end
+    redirect_to categories_path, notice: t(".success") if @category.update(category_params)
   end
 
   private

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -6,10 +6,6 @@ class SchedulesController < ApplicationController
 
 
   def show
-    if @schedule.nil?
-      return redirect_to root_path, alert: "Acesso não autorizado."
-    end
-
     @schedule = Schedule.find_by(id: params[:id])
     @schedule_items = @schedule.schedule_items.order(:start_time)
   end

--- a/app/models/ticket_batch.rb
+++ b/app/models/ticket_batch.rb
@@ -26,7 +26,7 @@ class TicketBatch < ApplicationRecord
   end
 
   def apply_discount
-    if self.discount_option != :no_discount
+    if self.discount_option != "no_discount"
       self.ticket_price /= 2
     end
   end

--- a/app/views/ticket_batches/index.html.erb
+++ b/app/views/ticket_batches/index.html.erb
@@ -18,7 +18,7 @@
         <div class="flex justify-between items-center px-8 flex-1">
           <div class="flex flex-col font-mono px-4 py-8 gap-4">
            <p class="font-extrabold text-primary text-2xl font-sans"></span><%= batch.name %></p>
-           <p class="font-normal text-textSecondary"><span class="font-bold text-textPrimary">Valor dos Ingressos: </span><%= number_to_currency batch.ticket_price %></p>
+           <p class="font-normal text-textSecondary"><span class="font-bold text-textPrimary">Valor do Ingresso: </span><%= number_to_currency batch.ticket_price %></p>
            <p class="font-normal text-textSecondary"><span class="font-bold text-textPrimary">Limite de Ingressos: </span><%= batch.tickets_limit %></p>
            <p class="font-normal text-textSecondary"><span class="font-bold text-textPrimary">Opção de Desconto: </span><%= TicketBatch.human_enum_name(:discount_option, batch.discount_option)%> </p>
           </div>

--- a/spec/system/keywords/user_remove_keyword_spec.rb
+++ b/spec/system/keywords/user_remove_keyword_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'Usuário remove associação de palavra-chave' do
+  context 'à uma categoria já existente' do
+    it 'com sucesso' do
+      user = create(:user, :admin)
+      ruby = FactoryBot.create(:category, name: 'Ruby')
+      backend = FactoryBot.create(:keyword, value: 'Backend')
+      CategoryKeyword.create(category: ruby, keyword: backend)
+      login_as user
+
+      visit category_path(ruby)
+      uncheck 'Backend'
+      click_on 'Atualizar'
+
+      expect(page).to have_content 'Categoria atualizada com sucesso.'
+      within "##{ruby.name}" do
+        expect(page).not_to have_content 'Backend'
+      end
+    end
+  end
+end

--- a/spec/system/ticket_batches/user_create_batches_spec.rb
+++ b/spec/system/ticket_batches/user_create_batches_spec.rb
@@ -15,16 +15,40 @@ describe 'Usuário cria lotes' do
     fill_in 'Data de Inicio', with: 1.week.from_now.strftime('%Y-%m-%d')
     fill_in 'Data Final', with: 3.weeks.from_now.strftime('%Y-%m-%d')
     fill_in 'Valor do Ingresso', with: 1000
-    select 'Meia Estudante', from: 'Opção de Desconto'
+    select 'Sem Desconto', from: 'Opção de Desconto'
     click_on 'Criar Lote'
 
     ticket_batch = TicketBatch.last
-    expect(page).to have_content ticket_batch.name
+    expect(page).to have_content 'Lote de Ingresso adicionado com sucesso.'
+    expect(page).to have_content 'Primeiro Lote'
+    expect(page).to have_content 'Limite de Ingressos: 30'
+    expect(page).to have_content 'Valor do Ingresso: R$ 1.000,00'
+    expect(page).to have_content 'Opção de Desconto: Sem Desconto'
     expect(page).to have_content I18n.l ticket_batch.start_date.to_date, format: :short
     expect(page).to have_content I18n.l ticket_batch.end_date.to_date, format: :short
-    expect(page).to have_content ticket_batch.ticket_price.to_s.sub('.', ',')
-    expect(page).to have_content TicketBatch.human_enum_name(:discount_option, ticket_batch.discount_option)
     expect(current_path).to eq event_ticket_batches_path(event)
+  end
+
+  it 'e adiciona desconto meia-estudante' do
+    user = create(:user)
+    create(:event, user: user)
+    login_as user
+
+    visit root_path
+    click_on 'Gerenciar'
+    click_on 'Lotes'
+    click_on '+ Lote'
+    fill_in 'Nome', with: 'Primeiro Lote - Meia Estudante'
+    fill_in 'Limite de Ingresso', with: 30
+    fill_in 'Data de Inicio', with: 1.week.from_now.strftime('%Y-%m-%d')
+    fill_in 'Data Final', with: 3.weeks.from_now.strftime('%Y-%m-%d')
+    fill_in 'Valor do Ingresso', with: 1000
+    select 'Meia Estudante', from: 'Opção de Desconto'
+    click_on 'Criar Lote'
+
+    expect(page).to have_content 'Primeiro Lote - Meia Estudante'
+    expect(page).to have_content 'Opção de Desconto: Meia Estudante'
+    expect(page).to have_content 'Valor do Ingresso: R$ 500,00'
   end
 
   it 'e falha por informar dados inválidos' do


### PR DESCRIPTION
## 1: Resolve o bug que aplicava desconto à qualquer ingresso
Agora o desconto só é aplicado à ingressos tenham algum tipo de desconto selecionado

## 2: Adicionado testes que garantem a remoção da associação entre categorias e palavras chaves
spec/system/keyword/user_remove_keyword_spec.rb

## 3: Removido Else do controller de agenda
O método **authorize_schedule_access** já garante que não chegará nil na action **show**

## 4: Removido If do controller de categoria
É impossível a action **update** falhar visto que ela é usada única e exclusivamente para associar palavras-chaves

# 100% dos testes passando, cobrindo 98.36% do app
![image](https://github.com/user-attachments/assets/bac3f6e4-5a6f-4fff-9ebe-c73222891a03)



Resolves #47 
Resolves #102 