### PR TITLE
Excluir Item de Agenda de Evento

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -56,7 +56,7 @@ class EventsController < ApplicationController
   end
 
   def history
-    @events = Event.all
+    @events = Event.with_discarded
   end
 
   private

--- a/app/controllers/schedule_items_controller.rb
+++ b/app/controllers/schedule_items_controller.rb
@@ -1,6 +1,6 @@
 class ScheduleItemsController < ApplicationController
   before_action :authenticate_user!
-  before_action :authorize_schedule_owner, only: [ :new, :create ]
+  before_action :authorize_schedule_owner, only: [ :new, :create, :destroy ]
 
   def new
     @schedule_item = @schedule.schedule_items.build
@@ -16,6 +16,13 @@ class ScheduleItemsController < ApplicationController
       flash.now[:alert] = "Não foi possível criar a atividade."
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @schedule_item = ScheduleItem.find_by(id: params[:id])
+
+    @schedule_item.discard!
+    redirect_to event_schedule_path(@schedule_item.schedule.event, @schedule_item.schedule), notice: "Item deletado com sucesso."
   end
 
   private

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -30,4 +30,16 @@ class VerificationsController < ApplicationController
   def user_verification_params
     params.require(:user).permit(:phone_number, :id_photo, :address_proof, user_address_attributes: [ :street, :number, :district, :city, :state, :zip_code ])
   end
+
+  def check_if_event_manager
+    if current_user && current_user.role != "event_manager"
+      redirect_to dashboard_path, alert: "Acesso não autorizado."
+    end
+  end
+
+  def check_if_event_manager
+    if current_user && current_user.role != "event_manager"
+      redirect_to dashboard_path, alert: "Acesso não autorizado."
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,8 @@
 class Event < ApplicationRecord
   include Discard::Model
+
+  default_scope -> { kept }
+
   belongs_to :user
 
   has_one_attached :logo

--- a/app/models/schedule_item.rb
+++ b/app/models/schedule_item.rb
@@ -1,6 +1,8 @@
 class ScheduleItem < ApplicationRecord
   include Discard::Model
 
+  default_scope -> { kept }
+
   belongs_to :schedule
   belongs_to :speaker, foreign_key: "responsible_email", primary_key: "email", optional: true
 

--- a/app/models/schedule_item.rb
+++ b/app/models/schedule_item.rb
@@ -1,4 +1,6 @@
 class ScheduleItem < ApplicationRecord
+  include Discard::Model
+
   belongs_to :schedule
   belongs_to :speaker, foreign_key: "responsible_email", primary_key: "email", optional: true
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,28 +1,30 @@
 <% if current_user.role == "event_manager"%>
-<div class="bg-white p-10 shadow-md rounded">
-  <div class="flex justify-between items-center">
-    <h1>Meus Eventos</h1>
+  <div class="bg-white p-10 shadow-md rounded">
+    <div class="flex justify-between items-center">
+      <h1>Meus Eventos</h1>
 
-    <%= link_to 'Criar Evento', new_event_path, class: 'form_button w-fit'%>
-  </div>
+      <%= link_to 'Criar Evento', new_event_path, class: 'form_button w-fit'%>
+    </div>
 
-  <div class="mt-4">
-    <% if @events.any? %>
-      <table class="w-full text-left table-auto">
-        <thead>
-          <tr>
-            <th class="px-4 py-2 border-b border-blue-gray-500">Nome</th>
-            <th class="px-4 py-2 border-b border-blue-gray-500">Status</th>
-            <th class="px-4 py-2 border-b border-blue-gray-500">Limite de participantes</th>
-            <th class="px-4 py-2 border-b border-blue-gray-500">Quando</th>
-            <th class="px-4 py-2 border-b border-blue-gray-500"></th>
-          </tr>
+    <div class="mt-4">
+      <% if @events.any? %>
+        <table class="w-full text-left table-auto">
+          <thead>
+            <tr>
+              <th class="px-4 py-2 border-b border-blue-gray-500">Nome</th>
+              <th class="px-4 py-2 border-b border-blue-gray-500">Status</th>
+              <th class="px-4 py-2 border-b border-blue-gray-500">Limite de participantes</th>
+              <th class="px-4 py-2 border-b border-blue-gray-500">Quando</th>
+              <th class="px-4 py-2 border-b border-blue-gray-500"></th>
+            </tr>
           </thead>
           <tbody>
-            <% @events.kept.each do |e| %>
+            <% @events.each do |e| %>
               <tr class="even:bg-gray-100">
                 <td class="px-4 py-2 border-b border-blue-gray-100"><%= e.name %></td>
-                <td class="px-4 py-2 border-b border-blue-gray-100"><p class="<%=e.status == 'published' ? "text-success font-medium" : "text-warning font-medium" %>"><%= Event.human_enum_name(:status, e.status) %></p></td>
+                <td class="px-4 py-2 border-b border-blue-gray-100">
+                  <p class="<%=e.status == 'published' ? "text-success font-medium" : "text-warning font-medium" %>"><%= Event.human_enum_name(:status, e.status) %></p>
+                </td>
                 <td class="px-4 py-2 border-b border-blue-gray-100"><%= e.participants_limit%></td>
                 <td class="px-4 py-2 border-b border-blue-gray-100"><%= l(e.start_date.to_date)%></td>
                 <td class="px-4 py-2 border-b border-blue-gray-100">
@@ -36,11 +38,11 @@
               </tr>
             <% end %>
           </tbody>
-      </table>
-    
-    <% else %>
-      <p>Você não possui eventos cadastrados.</p>
-    <% end %>
+        </table>
+
+      <% else %>
+        <p>Você não possui eventos cadastrados.</p>
+      <% end %>
+    </div>
   </div>
-</div>
 <% end %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -6,13 +6,16 @@
   %>
 </div>
 
-
 <section class="mt-10 flex flex-col gap-4" data-controller="schedule">
   <% if @schedule_items.empty? %>
     <h2 class="font-bold text-lg text-textPrimary">Ainda não atividades na Agenda deste dia de Evento.</h2>
   <% else %>
     <% @schedule_items.each do |item| %>
       <article class="flex items-center p-6 bg-white rounded-xl w-2/3">
+        <%= button_to event_schedule_item_path(item.schedule.event, item.schedule, item), method: :delete, class: 'danger_button mr-4', data: { turbo_method: :delete, turbo_confirm: "Tem certeza que deseja deletar o item de agenda:\n#{item.name}", test_id: "delete-#{item.id}" } do %>
+          <img src="<%= asset_path('bin.svg')%>" class="h-6 w-6 object-contain" style="max-width: 24px; max-height: 24px;"/>
+        <% end %>
+
         <% if item.schedule_type == "activity" %>
           <div class="flex pr-8 flex-col border-r-4 border-primary gap-1">
             <p class="font-extrabold text-primary"><%= l(item.start_time, format: :time_only) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :ticket_batches, only: [ :index, :new, :create ]
 
     resources :schedules, only: [ :show ] do
-      resources :schedule_items, as: :items, only: [ :new, :create ]
+      resources :schedule_items, as: :items, only: [ :new, :create, :destroy ]
     end
   end
 

--- a/db/migrate/20250205024835_add_discarded_at_to_schedule_items.rb
+++ b/db/migrate/20250205024835_add_discarded_at_to_schedule_items.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToScheduleItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :schedule_items, :discarded_at, :datetime
+    add_index :schedule_items, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_04_053127) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_05_024835) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -125,7 +125,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_04_053127) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code", null: false
+    t.datetime "discarded_at"
     t.index ["code"], name: "index_schedule_items_on_code", unique: true
+    t.index ["discarded_at"], name: "index_schedule_items_on_discarded_at"
     t.index ["schedule_id"], name: "index_schedule_items_on_schedule_id"
   end
 

--- a/spec/requests/schedule_items/user_delete_schedule_item_request_spec.rb
+++ b/spec/requests/schedule_items/user_delete_schedule_item_request_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe 'Usuário tentar deletar item de agenda' do
+  it 'e falha pois não está autenticado' do
+    event = create(:event)
+    schedule = create(:schedule, event: event)
+    schedule_item = create(:schedule_item, schedule: schedule)
+
+    delete event_schedule_item_path(event, schedule, schedule_item)
+
+    expect(response).to redirect_to new_user_session_path
+    expect(response).to have_http_status :found
+  end
+
+  it 'e não consegue deletar os itens de agenda dos outros' do
+    first_user = create(:user, email: 'marcos@email.com')
+    second_user = create(:user, email: 'joao@email.com')
+    event = create(:event, user: second_user, name: "Conferência Ruby")
+    schedule = create(:schedule, event: event)
+    schedule_item = create(:schedule_item, schedule: schedule, responsible_email: "marcos@email.com")
+
+    login_as first_user
+    delete event_schedule_item_path(event, schedule, schedule_item)
+
+
+    expect(response).to have_http_status :redirect
+    follow_redirect!
+    follow_redirect!
+    expect(response.body).to include 'Acesso não autorizado.'
+  end
+
+  it 'com sucesso' do
+    first_user = create(:user, email: 'marcos@email.com')
+    event = create(:event, user: first_user, name: "Conferência Ruby")
+    schedule = create(:schedule, event: event)
+    schedule_item = create(:schedule_item, schedule: schedule, responsible_email: "marcos@email.com")
+
+    login_as first_user
+    delete event_schedule_item_path(event, schedule, schedule_item)
+
+
+    expect(response).to have_http_status :redirect
+    follow_redirect!
+    expect(response.body).to include 'Item deletado com sucesso.'
+  end
+end

--- a/spec/system/schedule_items/user_can_delete_a_schedule_item_spec.rb
+++ b/spec/system/schedule_items/user_can_delete_a_schedule_item_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Usuário deleta um item de agenda' do
+  it 'com sucesso' do
+    user = create(:user)
+    category = create(:category, name: 'Tecnologia')
+    event = create(:event, name: 'Introdução ao RoR', user: user, categories: [ category ])
+    schedule = create(:schedule, event: event)
+    schedule_item = create(:schedule_item, schedule: schedule)
+
+    login_as user
+    visit root_path
+    find("a[test_id='manage-#{event.id}']").click
+    click_on schedule.date.strftime("%d/%m")
+    find("button[data-test-id='delete-#{schedule_item.id}']").click
+
+    expect(page).to have_content 'Item deletado com sucesso'
+  end
+end


### PR DESCRIPTION
Resolve #10 

## Adicionado botão para excluir um item de agenda
![image](https://github.com/user-attachments/assets/4c2878e9-9a6c-40bd-b711-9782fc16df59)

**Detalhes adicionais:**

- Foi usado soft delete no ScheduleItem para evitar problemas com a aplicação de palestrantes, já que lá existem dados que estão atrelados a um item de agenda da nossa aplicação, podendo causar algum conflito no futuro.

- Models que usam soft delete agora usam "kept" como escopo padrão para buscas no banco de dados, para evitar fornecer dados que já foram deletados.