### PR TITLE
Novos campos no endpoint events#show

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -43,9 +43,14 @@ class Api::V1::EventsController < Api::V1::ApiController
           date: schedule.date.strftime("%Y-%m-%d"),
           schedule_items: schedule.schedule_items.map do |item|
             {
+              code: item.code,
               name: item.name,
+              description: item.description,
               start_time: item.start_time,
-              end_time: item.end_time
+              end_time: item.end_time,
+              responsible_name: item.responsible_name,
+              responsible_email: item.responsible_email,
+              schedule_type: item.schedule_type
             }
           end
         }

--- a/app/controllers/api/v1/speakers_controller.rb
+++ b/app/controllers/api/v1/speakers_controller.rb
@@ -76,7 +76,7 @@ class Api::V1::SpeakersController < Api::V1::ApiController
     schedule_item = @speaker.schedule_items.find_by(code: params[:schedule_item_code])
     return render json: { error: "Palestrante não possui nenhum item de agenda com esse código." }, status: :not_found unless schedule_item
 
-      render json: schedule_item.as_json(except: [ :id, :updated_at ]), status: :ok
+    render json: schedule_item.as_json(except: [ :id, :updated_at ]), status: :ok
   end
 
   private

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -35,10 +35,4 @@ class VerificationsController < ApplicationController
       redirect_to dashboard_path, alert: "Acesso não autorizado."
     end
   end
-
-  def check_if_event_manager
-    if current_user && current_user.role != "event_manager"
-      redirect_to dashboard_path, alert: "Acesso não autorizado."
-    end
-  end
 end

--- a/spec/requests/api/v1/event_api_request_spec.rb
+++ b/spec/requests/api/v1/event_api_request_spec.rb
@@ -50,18 +50,13 @@ describe 'Event API' do
         :event, name: 'Formação de Churrasqueiros', user: user, status: 'published',
         address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional', participants_limit: 30,
         start_date:  (Time.now + 3.day).change(hour: 8, min: 0, sec: 0), end_date: (Time.now + 4.day).change(hour: 18, min: 0, sec: 0))
-
       event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
       event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
-
       event.save
-
       schedule = event.schedules.first
-
       ticket_batch = create(:ticket_batch, event: event,
         start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0),
         end_date: (Time.now + 2.day).change(hour: 18, min: 0, sec: 0))
-
       coffee_break = create(:schedule_item, schedule: schedule, name: 'Coffee Break', start_time: (Time.now + 1.day).change(hour: 9, min: 0, sec: 0), end_time: (Time.now + 1.day).change(hour: 10, min: 0, sec: 0))
       music_lesson = create(:schedule_item, schedule: schedule, name: 'Aula de música', start_time: (Time.now + 1.day).change(hour: 10, min: 0, sec: 0), end_time: (Time.now + 1.day).change(hour: 11, min: 0, sec: 0))
 
@@ -83,8 +78,14 @@ describe 'Event API' do
       expect(response.parsed_body['ticket_batches'][0]['ticket_price'].to_f).to eq (ticket_batch.ticket_price)
       expect(response.parsed_body['ticket_batches'][0]['code']).to eq ticket_batch.code
       expect(response.parsed_body['schedules'][0]['date']).to eq schedule.date.strftime('%Y-%m-%d')
+      expect(response.parsed_body['schedules'][0]['schedule_items'][0]['code']).to eq coffee_break.code
       expect(response.parsed_body['schedules'][0]['schedule_items'][0]['name']).to eq coffee_break.name
+      expect(response.parsed_body['schedules'][0]['schedule_items'][0]['description']).to eq coffee_break.description
+      expect(response.parsed_body['schedules'][0]['schedule_items'][0]['responsible_name']).to eq coffee_break.responsible_name
+      expect(response.parsed_body['schedules'][0]['schedule_items'][0]['responsible_email']).to eq coffee_break.responsible_email
+      expect(response.parsed_body['schedules'][0]['schedule_items'][0]['schedule_type']).to eq coffee_break.schedule_type
       expect(response.parsed_body['schedules'][0]['schedule_items'][1]['name']).to eq music_lesson.name
+      expect(response.parsed_body['schedules'][0]['schedule_items'][1]['code']).to eq music_lesson.code
     end
 
     it "e evento não existe" do


### PR DESCRIPTION
http://localhost:3000/api/v1/events/#{event.code}
### Como solicitado pela equipe de Participantes, foram adicionados os seguintes campos:

1. code
2. description
3. responsible_name
4. responsible_email
5. schedule_type

![image](https://github.com/user-attachments/assets/63e9692b-fcc5-4573-b164-16f64a9de50f)

Resolves #117 