### PR TITLE
Cria um anúncio oficial ao editar um item da agenda

### DIFF
--- a/spec/models/schedule_item_spec.rb
+++ b/spec/models/schedule_item_spec.rb
@@ -128,4 +128,59 @@ RSpec.describe ScheduleItem, type: :model do
       end
     end
   end
+
+  describe 'Cria um anuncio oficial' do
+    it 'cria um anúncio oficial quando um item de agenda é atualizado' do
+      user = create(:user)
+      event = create(:event, user: user)
+      schedule = create(:schedule, event: event)
+      schedule_item = create(:schedule_item, schedule: schedule, name: 'Atividade Antiga')
+
+      schedule_item.update(name: 'Novo Nome')
+
+      expect(event.announcements.count).to eq(1)
+
+      announcement = event.announcements.last
+      expect(announcement.title).to eq('Atualização na atividade Novo Nome')
+      expect(announcement.description.to_plain_text).to include("Nome alterado de 'Atividade Antiga' para 'Novo Nome'")
+    end
+
+    it 'não cria um anúncio se não houver alterações relevantes' do
+      user = create(:user)
+      event = create(:event, user: user)
+      schedule = create(:schedule, event: event)
+      schedule_item = create(:schedule_item, schedule: schedule, name: 'Atividade Antiga')
+
+      schedule_item.update(name: 'Atividade Antiga')
+
+      expect(event.announcements.count).to eq(0)
+    end
+
+    it 'cria um anúncio com múltiplas mudanças' do
+      user = create(:user)
+      event = create(:event, user: user)
+      schedule = create(:schedule, event: event)
+      schedule_item = create(:schedule_item,
+        schedule: schedule,
+        name: 'Atividade Antiga',
+        start_time: '2025-02-10 09:00:00',
+        end_time: '2025-02-10 10:00:00'
+      )
+
+      schedule_item.update(
+        name: 'Nova Atividade',
+        start_time: '2025-02-10 10:30:00',
+        end_time: '2025-02-10 11:30:00'
+      )
+
+      expect(event.announcements.count).to eq(1)
+
+      announcement = event.announcements.last
+      expect(announcement.title).to eq('Atualização na atividade Nova Atividade')
+      description_text = announcement.description.to_plain_text
+      expect(description_text).to include("Nome alterado de 'Atividade Antiga' para 'Nova Atividade'")
+      expect(description_text).to include("Início alterado de '09:00' para '10:30'")
+      expect(description_text).to include("Término alterado de '10:00' para '11:30'")
+    end
+  end
 end

--- a/spec/system/announcement/system_create_annoucement_when_editing_schedule_item_spec.rb
+++ b/spec/system/announcement/system_create_annoucement_when_editing_schedule_item_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'Sistema cria anuncio ao editar um item de agenda' do
+  it 'com sucesso' do
+    user = create(:user)
+    event = create(:event, name: 'Introdução ao RoR', user: user)
+    event.published!
+    schedule = create(:schedule, event: event)
+    schedule_item = create(:schedule_item, schedule: schedule, name: 'Atividade')
+
+    schedule_item.update(name: 'Novo Nome')
+
+    login_as user
+
+    visit event_announcements_path(event)
+
+    expect(page).to have_content 'Atualização na atividade Novo Nome'
+    expect(page).to have_content "As seguintes alterações foram feitas: Nome alterado de 'Atividade' para 'Novo Nome'."
+  end
+
+  it 'não cria anuncio se nao houver alterações' do
+    user = create(:user)
+    event = create(:event, name: 'Introdução ao RoR', user: user)
+    event.published!
+    schedule = create(:schedule, event: event)
+    create(:schedule_item, schedule: schedule, name: 'Curso Rails')
+
+    login_as user
+
+    visit event_announcements_path(event)
+
+    expect(page).not_to have_content 'Atualização na atividade Curso Rails'
+  end
+end


### PR DESCRIPTION
Ao editar um item da agenda é criado um anúncio oficial avisando da mudança, com intuíto de informar melhor os participantes do evento.

![image](https://github.com/user-attachments/assets/74cc0c2d-6d76-445b-9057-377fdcaac50f)

Resolve #126 