### PR TITLE
Endpoint Events ganha novo campo

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::EventsController < Api::V1::ApiController
         start_date: event.start_date,
         end_date: event.end_date
       }
-      
+
       data.delete(:address) if event.online?
       data
     end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -3,11 +3,12 @@ class Api::V1::EventsController < Api::V1::ApiController
     query = params[:query]
     @events = Event.published.search(query)
 
-    render status: :ok, json: { events: @events.map do |event|
-      {
+    events_data = @events.map do |event|
+      data = {
         code: event.code,
         name: event.name,
         description: event.description.body ? event.description.body.to_html : "",
+        event_type: event.event_type,
         address: event.address,
         logo_url: event.logo.attached? ? url_for(event.logo) : nil,
         banner_url: event.banner.attached? ? url_for(event.banner) : nil,
@@ -16,21 +17,26 @@ class Api::V1::EventsController < Api::V1::ApiController
         start_date: event.start_date,
         end_date: event.end_date
       }
+      
+      data.delete(:address) if event.online?
+      data
     end
-    }
+
+    render status: :ok, json: { events: events_data }
   end
 
   def show
     event = Event.published.find_by(code: params[:code])
 
     unless event
-      return render status: :not_found, json: { error: "Event not found" }
+      return render status: :not_found, json: { error: "Evento não encontrado" }
     end
 
-    render status: :ok, json: {
+    event_data = {
       code: event.code,
       name: event.name,
       description: event.description.body ? event.description.body.to_html : "",
+      event_type: event.event_type,
       address: event.address,
       logo_url: event.logo.attached? ? url_for(event.logo) : nil,
       banner_url: event.banner.attached? ? url_for(event.banner) : nil,
@@ -57,5 +63,8 @@ class Api::V1::EventsController < Api::V1::ApiController
         }
       end
     }
+
+    event_data.delete(:address) if event.online?
+    render status: :ok, json: event_data
   end
 end

--- a/spec/requests/api/v1/event_api_request_spec.rb
+++ b/spec/requests/api/v1/event_api_request_spec.rb
@@ -11,7 +11,7 @@ describe 'Event API' do
         event_type: :inperson,
         address: 'Rua das Laranjeiras, 123',
         participants_limit: 30,
-        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0), 
+        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0),
         end_date: (Time.now + 3.day).change(hour: 18, min: 0, sec: 0)
         )
       event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
@@ -52,7 +52,7 @@ describe 'Event API' do
         description: 'Aprenda a fazer churrasco como um profissional',
         event_type: :online,
         participants_limit: 30,
-        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0), 
+        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0),
         end_date: (Time.now + 3.day).change(hour: 18, min: 0, sec: 0)
         )
       event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')

--- a/spec/requests/api/v1/event_api_request_spec.rb
+++ b/spec/requests/api/v1/event_api_request_spec.rb
@@ -4,62 +4,93 @@ describe 'Event API' do
   context 'Usuário vê lista de eventos' do
     it 'com sucesso' do
       user = create(:user)
-
       category = Category.create!(name: 'Palestra')
-
-      event = build(
-        :event, name: 'Formação de Churrasqueiros', user: user, status: 'published',
-        address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional', participants_limit: 30,
-        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0), end_date: (Time.now + 3.day).change(hour: 18, min: 0, sec: 0))
-
-
+      event = build(:event, user: user, status: 'published',
+        name: 'Formação de Churrasqueiros',
+        description: 'Aprenda a fazer churrasco como um profissional',
+        event_type: :inperson,
+        address: 'Rua das Laranjeiras, 123',
+        participants_limit: 30,
+        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0), 
+        end_date: (Time.now + 3.day).change(hour: 18, min: 0, sec: 0)
+        )
       event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
       event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
-
       event.save
-
-      draft_event = create(
-          :event, name: 'Formação de Padeiros', user: user, status: 'draft',
-          address: 'Rua dos ipês, 343', description: 'Aprenda a fazer Pão como um profissional', categories: [ category ])
+      draft_event = create(:event, user: user, status: 'draft',
+        name: 'Formação de Padeiros',
+        address: 'Rua dos ipês, 343',
+        description: 'Aprenda a fazer Pão como um profissional',
+        categories: [ category ]
+        )
 
       get '/api/v1/events'
 
       expect(response).to have_http_status :success
       expect(response.content_type).to include('application/json')
-      expect(response.parsed_body['events'][0]['name']).to include(event.name)
-      expect(response.parsed_body['events'][0]['address']).to include(event.address)
-      expect(response.parsed_body['events'][0]['description']).to include(event.description.body.to_html)
       expect(response.parsed_body['events'][0]['code']).to eq event.code
+      expect(response.parsed_body['events'][0]['name']).to include('Formação de Churrasqueiros')
+      expect(response.parsed_body['events'][0]['description']).to include('Aprenda a fazer churrasco como um profissional')
+      expect(response.parsed_body['events'][0]['event_type']).to include('inperson')
+      expect(response.parsed_body['events'][0]['address']).to include('Rua das Laranjeiras, 123')
       expect(response.parsed_body['events'][0]['logo_url']).to eq url_for(event.logo)
       expect(response.parsed_body['events'][0]['banner_url']).to eq url_for(event.banner)
       expect(response.parsed_body['events'][0]['participants_limit']).to eq event.participants_limit
       expect(response.parsed_body['events'][0]['event_owner']).to eq event.user.name
       expect(response.parsed_body['events'][0]['start_date']).to eq event.start_date.iso8601(3)
       expect(response.parsed_body['events'][0]['end_date']).to eq event.end_date.iso8601(3)
-      expect(response.parsed_body['events']).not_to include(draft_event.name)
-      expect(response.parsed_body['events']).not_to include(draft_event.address)
-      expect(response.parsed_body['events']).not_to include(draft_event.description)
+      expect(response.parsed_body['events']).not_to include('Formação de Padeiros')
+      expect(response.parsed_body['events']).not_to include('Rua dos ipês, 343')
+      expect(response.parsed_body['events']).not_to include('Aprenda a fazer Pão como um profissional')
       expect(response.parsed_body['events']).not_to include(draft_event.id)
+    end
+
+    it 'e se o evento for online, não vê o endereço' do
+      user = create(:user)
+      event = build(:event, user: user, status: 'published',
+        name: 'Formação de Churrasqueiros',
+        description: 'Aprenda a fazer churrasco como um profissional',
+        event_type: :online,
+        participants_limit: 30,
+        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0), 
+        end_date: (Time.now + 3.day).change(hour: 18, min: 0, sec: 0)
+        )
+      event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
+      event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
+      event.save
+
+      get '/api/v1/events'
+
+      expect(response).to have_http_status :success
+      expect(response.content_type).to include('application/json')
+      expect(response.parsed_body['events'][0]['code']).to eq event.code
+      expect(response.parsed_body['events'][0]['name']).to include('Formação de Churrasqueiros')
+      expect(response.parsed_body['events'][0]['description']).to include('Aprenda a fazer churrasco como um profissional')
+      expect(response.parsed_body['events'][0]['event_type']).to include('online')
+      expect(response.parsed_body['events'][0]).not_to have_key('address')
     end
 
     it 'e envia uma query' do
       user = create(:user)
-
       category = Category.create!(name: 'Palestra')
-
-      event = build(
-        :event, name: 'Formação de Churrasqueiros', user: user, status: 'published',
-        address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional', participants_limit: 30,
-        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0), end_date: (Time.now + 3.day).change(hour: 18, min: 0, sec: 0))
-
+      event = build(:event, user: user, status: 'published',
+        name: 'Formação de Churrasqueiros',
+        description: 'Aprenda a fazer churrasco como um profissional',
+        event_type: :inperson,
+        address: 'Rua das Laranjeiras, 123',
+        participants_limit: 30,
+        start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0),
+        end_date: (Time.now + 3.day).change(hour: 18, min: 0, sec: 0)
+        )
       event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
       event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
-
       event.save
-
-      create(
-          :event, name: 'Formação de Padeiros', user: user, status: 'published',
-          address: 'Rua dos ipês, 343', description: 'Aprenda a fazer Pão como um profissional', categories: [ category ])
+      create(:event, user: user, status: 'published',
+        name: 'Formação de Padeiros',
+        description: 'Aprenda a fazer Pão como um profissional',
+        address: 'Rua dos ipês, 343',
+        categories: [ category ]
+        )
 
       get '/api/v1/events', params: { query: event.name }
 
@@ -82,10 +113,15 @@ describe 'Event API' do
   context 'Usuário ve detalhes' do
     it 'com sucesso' do
       user = create(:user)
-      event = build(
-        :event, name: 'Formação de Churrasqueiros', user: user, status: 'published',
-        address: 'Rua das Laranjeiras, 123', description: 'Aprenda a fazer churrasco como um profissional', participants_limit: 30,
-        start_date:  (Time.now + 3.day).change(hour: 8, min: 0, sec: 0), end_date: (Time.now + 4.day).change(hour: 18, min: 0, sec: 0))
+      event = build(:event, user: user, status: 'published',
+        name: 'Formação de Churrasqueiros',
+        description: 'Aprenda a fazer churrasco como um profissional',
+        event_type: :inperson,
+        address: 'Rua das Laranjeiras, 123',
+        participants_limit: 30,
+        start_date:  (Time.now + 3.day).change(hour: 8, min: 0, sec: 0),
+        end_date: (Time.now + 4.day).change(hour: 18, min: 0, sec: 0)
+        )
       event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
       event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
       event.save
@@ -93,17 +129,22 @@ describe 'Event API' do
       ticket_batch = create(:ticket_batch, event: event,
         start_date:  (Time.now + 1.day).change(hour: 8, min: 0, sec: 0),
         end_date: (Time.now + 2.day).change(hour: 18, min: 0, sec: 0))
-      coffee_break = create(:schedule_item, schedule: schedule, name: 'Coffee Break', start_time: (Time.now + 1.day).change(hour: 9, min: 0, sec: 0), end_time: (Time.now + 1.day).change(hour: 10, min: 0, sec: 0))
-      music_lesson = create(:schedule_item, schedule: schedule, name: 'Aula de música', start_time: (Time.now + 1.day).change(hour: 10, min: 0, sec: 0), end_time: (Time.now + 1.day).change(hour: 11, min: 0, sec: 0))
+      coffee_break = create(:schedule_item, schedule: schedule, name: 'Coffee Break',
+        start_time: (Time.now + 1.day).change(hour: 9, min: 0, sec: 0),
+        end_time: (Time.now + 1.day).change(hour: 10, min: 0, sec: 0))
+      music_lesson = create(:schedule_item, schedule: schedule, name: 'Aula de música',
+        start_time: (Time.now + 1.day).change(hour: 10, min: 0, sec: 0),
+        end_time: (Time.now + 1.day).change(hour: 11, min: 0, sec: 0))
 
       get "/api/v1/events/#{event.code}"
 
       expect(response).to have_http_status :success
       expect(response.content_type).to include('application/json')
-      expect(response.parsed_body['name']).to include(event.name)
-      expect(response.parsed_body['address']).to include(event.address)
-      expect(response.parsed_body['description']).to include(event.description.body.to_html)
       expect(response.parsed_body['code']).to eq event.code
+      expect(response.parsed_body['name']).to include('Formação de Churrasqueiros')
+      expect(response.parsed_body['description']).to include(event.description.body.to_html)
+      expect(response.parsed_body['event_type']).to include('inperson')
+      expect(response.parsed_body['address']).to include('Rua das Laranjeiras, 123')
       expect(response.parsed_body['logo_url']).to eq url_for(event.logo)
       expect(response.parsed_body['banner_url']).to eq url_for(event.banner)
       expect(response.parsed_body['participants_limit']).to eq event.participants_limit
@@ -122,6 +163,31 @@ describe 'Event API' do
       expect(response.parsed_body['schedules'][0]['schedule_items'][0]['schedule_type']).to eq coffee_break.schedule_type
       expect(response.parsed_body['schedules'][0]['schedule_items'][1]['name']).to eq music_lesson.name
       expect(response.parsed_body['schedules'][0]['schedule_items'][1]['code']).to eq music_lesson.code
+    end
+
+    it 'e se o evento for online, não vê o endereço' do
+      user = create(:user)
+      event = build(:event, user: user, status: 'published',
+        name: 'Formação de Churrasqueiros',
+        description: 'Aprenda a fazer churrasco como um profissional',
+        event_type: :online,
+        participants_limit: 30,
+        start_date:  (Time.now + 3.day).change(hour: 8, min: 0, sec: 0),
+        end_date: (Time.now + 4.day).change(hour: 18, min: 0, sec: 0)
+        )
+      event.logo.attach(io: File.open('spec/support/images/logo.png'), filename: 'logo.png', content_type: 'img/png')
+      event.banner.attach(io: File.open('spec/support/images/banner.jpg'), filename: 'banner.png', content_type: 'img/jpg')
+      event.save
+
+      get "/api/v1/events/#{event.code}"
+
+      expect(response).to have_http_status :success
+      expect(response.content_type).to include('application/json')
+      expect(response.parsed_body['code']).to eq event.code
+      expect(response.parsed_body['name']).to include('Formação de Churrasqueiros')
+      expect(response.parsed_body['description']).to include(event.description.body.to_html)
+      expect(response.parsed_body['event_type']).to include('online')
+      expect(response.parsed_body).not_to have_key('address')
     end
 
     it "e evento não existe" do


### PR DESCRIPTION
## Solicitado pela equipe de Participantes: Add "event_type"

### Events / Index
Evento Presencial
![image](https://github.com/user-attachments/assets/f606c9c0-e8cd-4664-a5d9-51795eb388f9)

Evento Online (Campo "address" não enviado)
![image](https://github.com/user-attachments/assets/9aa9d937-2501-4599-a275-dcb55684efa1)

### Events / Show
Evento Presencial
![image](https://github.com/user-attachments/assets/3c15ddeb-6f15-44d8-bac6-e995c875c88c)

Evento Online (Campo "address" não enviado)
![image](https://github.com/user-attachments/assets/92b54840-f901-4bba-a281-b32ffb0c20ab)


Resolves #140 