### PR TITLE
Fix: Remover valores fixos das páginas de dashboard

### DIFF
--- a/app/views/dashboard/_admin.html.erb
+++ b/app/views/dashboard/_admin.html.erb
@@ -1,16 +1,11 @@
 <div class="flex flex-col gap-4">
-  <div class="border-l-4 pl-4 py-2 flex flex-col border-blue-800">
-    <h2>Total de vendas na plataforma: R$42.000,00</h2>
-    <p>No último mês: R$2.000,00</p>
-  </div>
-
   <div class="grid grid-cols-2 w-full mt-6 gap-10">
     <div class="flex flex-col gap-8" id="events-stats">
       <h2>Detalhes de eventos</h2>
 
       <div class="ml-6 flex gap-16 text-center items-center">
         <div>
-          <strong class="text-3xl underline underline-offset-8"><%= @events_count %></strong>
+          <strong class="text-3xl underline underline-offset-8 decoration-primary"><%= @events_count %></strong>
 
           <p class="mt-4"><%= @events_count == 1 ? 'evento criado' : 'eventos criados' %></p>
         </div>
@@ -18,7 +13,7 @@
         <div class="h-full w-px bg-gray-300"></div>
 
         <div>
-          <strong class="text-3xl underline underline-offset-8"><%= @published_events_count %></strong>
+          <strong class="text-3xl underline underline-offset-8 decoration-primary"><%= @published_events_count %></strong>
 
           <p class="mt-4"><%= @published_events_count == 1 ? 'evento publicado' : 'eventos publicados' %></p>
         </div>
@@ -38,11 +33,11 @@
                   <p class="text-sm">Evento publicado por <%= event.user.name %> <%= event.user.family_name %></p>
                   <p class="text-sm">
                     <% if event.start_date > Time.current %>
-                      O evento irá começar em <%= l event.start_date, format: "%-d de %B de %Y" %>
+                      Começa em <%=  distance_of_time_in_words event.start_date, Time.now %>
                     <% elsif event.end_date.present? && event.end_date < Time.current %>
-                      O evento terminou em <%= l event.end_date, format: "%-d de %B de %Y" %>
+                      O evento terminou há <%=  distance_of_time_in_words event.start_date, Time.now %>
                     <% else %>
-                      O evento já começou! Iniciado em <%= l event.start_date, format: "%-d de %B de %Y" %>
+                      O evento já começou! Iniciado <%=  distance_of_time_in_words event.start_date, Time.now %> atrás
                     <% end %>
                   </p>
                 </div>
@@ -70,7 +65,7 @@
 
           <div class="flex gap-16 text-center items-center">
             <div>
-              <strong class="text-3xl underline underline-offset-8"><%= @users_count %></strong>
+              <strong class="text-3xl underline underline-offset-8 decoration-primary"><%= @users_count %></strong>
 
               <p class="mt-4"><%= @users_count == 1 ? 'usuário cadastrado' : 'usuários cadastrados' %></p>
             </div>
@@ -78,7 +73,7 @@
             <div class="h-full w-px bg-gray-300"></div>
 
             <div>
-              <strong class="text-3xl underline underline-offset-8"><%= @verified_users_count %></strong>
+              <strong class="text-3xl underline underline-offset-8 decoration-primary"><%= @verified_users_count %></strong>
 
               <p class="mt-4"><%= @verified_users_count == 1 ? 'usuário verificado' : 'usuários verificados' %></p>
             </div>

--- a/app/views/dashboard/_event_manager.html.erb
+++ b/app/views/dashboard/_event_manager.html.erb
@@ -1,9 +1,4 @@
 <div class="flex flex-col gap-4">
-  <div class="border-l-4 pl-4 py-2 flex flex-col border-blue-800">
-    <h2>Seu lucro total na plataforma: <%= number_to_currency 20_000 %></h2>
-    <p>No último mês: R$2.000,00</p>
-  </div>
-
   <div class="grid grid-cols-2 w-full mt-6 gap-10">
     <div class="flex flex-col gap-8">
       <h2>Seus eventos</h2>

--- a/spec/system/dashboard/user_views_dashboard_spec.rb
+++ b/spec/system/dashboard/user_views_dashboard_spec.rb
@@ -34,7 +34,6 @@ describe 'Usuário visualiza a dashboard' do
     expect(current_path).to eq dashboard_path
     first_event.reload
     second_event.reload
-    expect(page).to have_content "Seu lucro total na plataforma: R$ 20.000,00"
     within "#created-events" do
       expect(page).to have_content "3"
       expect(page).to have_content "eventos criados"


### PR DESCRIPTION
Páginas de dashboard estavam com valores fixos para demonstrar que eram uma funcionalidade pretendida, mas na reunião de planejamento da apresentação foi decidido remover esses valores fixos

Dashboard de admin
![image](https://github.com/user-attachments/assets/f040447a-11ad-40eb-a14d-407e740649ee)

Dashboard de event_manager
![image](https://github.com/user-attachments/assets/992393bd-5bcc-4d84-b090-ee13fb2389a4)